### PR TITLE
Update example_usage.rb to include changes to finalName

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You can then install it using:
 Setup the converter details by creating a new `BuildVu` object:
 ```ruby
 require 'buildvu'
-buildvu = BuildVu.new('localhost:8080/microservice-example')
+buildvu = BuildVu.new('localhost:8080/buildvu-microservice')
 ```
 
 You can now convert files by calling the methods available. `convert()` will start the conversion process. For example to convert to html5:

--- a/example_usage.rb
+++ b/example_usage.rb
@@ -1,6 +1,6 @@
 require 'buildvu'
 
-buildvu = BuildVu.new'localhost:8080/microservice-example'
+buildvu = BuildVu.new'localhost:8080/buildvu-microservice'
 
 # Upload a local file to the BuildVu microservice
 # convert() returns a hash collection with the conversion results.

--- a/lib/buildvu/version.rb
+++ b/lib/buildvu/version.rb
@@ -1,3 +1,3 @@
 class BuildVu
-  VERSION = "3.0.1"
+  VERSION = "3.0.2"
 end


### PR DESCRIPTION
Changed the buildvu variable to buildvu-microservice, this is due to the changes to the finalName in the pom.xml in buildvu-microservice-example